### PR TITLE
Add general filter option

### DIFF
--- a/bin/conjur-ldap-sync
+++ b/bin/conjur-ldap-sync
@@ -11,7 +11,8 @@ class App
   include Methadone::CLILogging
 
   main do
-    Conjur::Ldap::Sync.run_sync options
+    #Conjur::Ldap::Sync.run_sync options
+    puts options
   end
 
   version Conjur::Ldap::Sync::VERSION
@@ -51,6 +52,16 @@ class App
   on('--user-object-classes CLASS1,CLASS2,...', Array,
      'LDAP objectClasses that should be imported as users') do |ocs|
     options[:user_object_classes] = ocs
+  end
+
+  on('--group-filter FILTER',
+      'LDAP filter to select groups for import (overrides --group-object-classes)') do |filter|
+    options[:group_filter] = filter
+  end
+
+  on('--user-filter FILTER',
+      'LDAP filter to select users for import (overrides --user-object-classes') do |filter|
+    options[:user_filter] = filter
   end
 
   on '--source-tag TAG',

--- a/lib/conjur/ldap/adapter.rb
+++ b/lib/conjur/ldap/adapter.rb
@@ -124,11 +124,11 @@ module Conjur::Ldap
     end
 
     def groups_filter
-      object_class_filter group_object_classes
+      options[:group_filter] || object_class_filter(group_object_classes)
     end
 
     def users_filter
-      object_class_filter user_object_classes
+      options[:user_filter] || object_class_filter(user_object_classes)
     end
 
     def object_class_filter object_classes

--- a/spec/adapter_spec.rb
+++ b/spec/adapter_spec.rb
@@ -66,6 +66,22 @@ describe Conjur::Ldap::Adapter do
       it_should_behave_like 'an object class filter method'
     end
 
+    context 'with --user-filter and --group-filter' do
+      let(:group_filter){ '(&(ou=ConjurGroups)(objectClass=group))' }
+      let(:user_filter){'(&(ou=ConjurGroups)(objectClass=group))' }
+      let(:options){ {group_filter: group_filter, user_filter: user_filter} }
+
+      describe '#users_filter' do
+        it('returns the user_filter option'){
+          expect(subject.users_filter).to eq(user_filter) }
+      end
+
+      describe '#groups_filter' do
+        it('returns the user_filter option'){
+          expect(subject.users_filter).to eq(user_filter) }
+      end
+    end
+
     shared_examples_for 'a find method' do
       let(:base_dn){ 'dc=conjur,dc=net' }
       let(:directory){ double('directory', base_dn: base_dn) }


### PR DESCRIPTION
Adds `--user-filter` and `--group-filter` options that override the `objectClass` filters and provide the raw LDAP filter used to select users and groups.